### PR TITLE
Matrix-linkkien lisäys

### DIFF
--- a/index.md
+++ b/index.md
@@ -7,6 +7,7 @@ Tältä sivustolta löydät liittymislinkit [Piraattinuorten](https://pinu.fi/)
 käytössä oleviin pikaviestimiin.
 
 * [Discord](/discord.html)
+* [Matrix](/matrix.html)
 * [Perinteinen IRC](/irc.html) ja [webirc](/webirc.html)
 * [Telegram](/telegram.html)
 

--- a/redirects/matrix.md
+++ b/redirects/matrix.md
@@ -1,5 +1,5 @@
 ---
-redirect_to: https://riot.im/app/#/group/+piraattinuoret:matrix.org
+redirect_to: matrix:r/piraattinuoret:pikaviestin.fi
 permalink: /matrix.html
 sitemap: false
 ---

--- a/redirects/matrixhallitus.md
+++ b/redirects/matrixhallitus.md
@@ -1,0 +1,5 @@
+---
+redirect_to: matrix:r/piraattinuoret-hallitus:pikaviestin.fi
+permalink: /matrixhallitus.html
+sitemap: false
+---


### PR DESCRIPTION
Pääkanavalle pääsee joko koputtamalla tai kuulumalla puolueen spaceen tai suomalaisia Matrix-huoneita listaavaan spaceen. Hallituksen huoneeseen pääsee koputtamalla tai kuulumalla puolueen spaceen.

Hallituksen telegrammia ei ollut index.md -tiedostossa, joten en alkanut lisäämään sitä sinne.